### PR TITLE
Feature/add member

### DIFF
--- a/src/Command/Domain/Events/GroupChatCreated.php
+++ b/src/Command/Domain/Events/GroupChatCreated.php
@@ -4,14 +4,9 @@ declare(strict_types=1);
 
 namespace Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Events;
 
-use J5ik2o\EventStoreAdapterPhp\Event;
 use DateTimeImmutable;
 use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models\GroupChatId;
 use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models\GroupChatName;
-
-interface GroupChatEvent extends Event {
-    public function getAggregateId(): GroupChatId;
-}
 
 class GroupChatCreated implements GroupChatEvent {
     private readonly string $typeName;

--- a/src/Command/Domain/Events/GroupChatCreated.php
+++ b/src/Command/Domain/Events/GroupChatCreated.php
@@ -8,13 +8,13 @@ use DateTimeImmutable;
 use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models\GroupChatId;
 use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models\GroupChatName;
 
-class GroupChatCreated implements GroupChatEvent {
-    private readonly string $typeName;
-    private readonly string $id;
-    private readonly GroupChatId $aggregateId;
-    private readonly GroupChatName $name;
-    private readonly int $sequenceNumber;
-    private readonly DateTimeImmutable $occurredAt;
+readonly class GroupChatCreated implements GroupChatEvent {
+    private string $typeName;
+    private string $id;
+    private GroupChatId $aggregateId;
+    private GroupChatName $name;
+    private int $sequenceNumber;
+    private DateTimeImmutable $occurredAt;
 
     public function __construct(
         string $id,

--- a/src/Command/Domain/Events/GroupChatEvent.php
+++ b/src/Command/Domain/Events/GroupChatEvent.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Events;
+
+use J5ik2o\EventStoreAdapterPhp\Event;
+use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models\GroupChatId;
+
+interface GroupChatEvent extends Event {
+    public function getAggregateId(): GroupChatId;
+}

--- a/src/Command/Domain/Events/GroupChatMemberAdded.php
+++ b/src/Command/Domain/Events/GroupChatMemberAdded.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Events;
+
+use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models\GroupChatId;
+use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models\Member;
+use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models\MemberId;
+use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models\MemberRole;
+use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models\UserAccountId;
+use DateTimeImmutable;
+
+readonly class GroupChatMemberAdded implements GroupChatEvent {
+    private string $id;
+    private GroupChatId $aggregateId;
+    private Member $member;
+    private int $sequenceNumber;
+    private UserAccountId $executorId;
+    private DateTimeImmutable $occurredAt;
+    public function __construct(
+        string $id,
+        GroupChatId $aggregateId,
+        MemberId $memberId,
+        UserAccountId $userAccountId,
+        MemberRole $role,
+        UserAccountId $executorId,
+        int $sequenceNumber,
+        DateTimeImmutable $occurredAt
+    ) {
+        $this->id = $id;
+        $this->aggregateId = $aggregateId;
+        $this->member = new Member($memberId, $userAccountId, $role);
+        $this->sequenceNumber = $sequenceNumber;
+        $this->executorId = $executorId;
+        $this->occurredAt = $occurredAt;
+    }
+
+    public function getId(): string {
+        return $this->id;
+    }
+
+    public function getTypeName(): string {
+        return "GroupChatMemberAdded";
+    }
+
+    public function getSequenceNumber(): int {
+        return $this->sequenceNumber;
+    }
+
+    public function isCreated(): bool {
+        return true;
+    }
+
+    public function getOccurredAt(): DateTimeImmutable {
+        return $this->occurredAt;
+    }
+
+    public function getAggregateId(): GroupChatId {
+        return $this->aggregateId;
+    }
+
+    public function jsonSerialize(): mixed {
+        return [
+            'id' => $this->id,
+            'typeName' => $this->getTypeName(),
+            'aggregateId' => $this->aggregateId,
+            'member' => $this->member,
+            'sequenceNumber' => $this->sequenceNumber,
+            'executorId' => $this->executorId,
+            'occurredAt' => $this->occurredAt,
+        ];
+    }
+}

--- a/src/Command/Domain/GroupChat.php
+++ b/src/Command/Domain/GroupChat.php
@@ -6,8 +6,6 @@ namespace Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain;
 
 use J5ik2o\EventStoreAdapterPhp\Aggregate;
 use J5ik2o\EventStoreAdapterPhp\AggregateId;
-use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Events\GroupChatCreated;
-use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Events\GroupChatMemberAdded;
 use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models\MemberId;
 use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models\MemberRole;
 use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models\GroupChatId;
@@ -43,12 +41,12 @@ readonly class GroupChat implements Aggregate {
     /**
      * @param GroupChatName $name
      * @param UserAccountId $executorId
-     * @return array{0: GroupChat, 1: GroupChatCreated}
+     * @return GroupChatWithEventPair
      */
     public static function create(
         GroupChatName $name,
         UserAccountId $executorId
-    ): array {
+    ): GroupChatWithEventPair {
         $id = new GroupChatId();
         $members = Members::create($executorId);
         $messages = new Messages([]);
@@ -66,7 +64,7 @@ readonly class GroupChat implements Aggregate {
             $id,
             $name
         );
-        return [$aggregate, $event];
+        return new GroupChatWithEventPair($aggregate, $event);
     }
 
     /**
@@ -74,14 +72,14 @@ readonly class GroupChat implements Aggregate {
      * @param UserAccountId $userAccountId
      * @param MemberRole $role
      * @param UserAccountId $executorId
-     * @return array{0: GroupChat, 1: GroupChatMemberAdded}
+     * @return GroupChatWithEventPair
      */
     public function addMember(
         MemberId $memberId,
         UserAccountId $userAccountId,
         MemberRole $role,
         UserAccountId $executorId
-    ): array {
+    ): GroupChatWithEventPair {
         // TODO: Error handling
         $newMembers = $this->getMembers()->addMember($userAccountId);
         $newState = new GroupChat(
@@ -100,7 +98,7 @@ readonly class GroupChat implements Aggregate {
             $newState->getSequenceNumber(),
             $executorId
         );
-        return [$newState, $event];
+        return new GroupChatWithEventPair($newState, $event);
     }
 
     public function getName(): GroupChatName {

--- a/src/Command/Domain/GroupChat.php
+++ b/src/Command/Domain/GroupChat.php
@@ -83,23 +83,23 @@ readonly class GroupChat implements Aggregate {
         UserAccountId $executorId
     ): array {
         // TODO: Error handling
-        $event = GroupChatEventFactory::ofMemberAdded(
-            $this->id,
-            $memberId,
-            $userAccountId,
-            $role,
-            $executorId
-        );
         $newMembers = $this->getMembers()->addMember($userAccountId);
         $newState = new GroupChat(
             $this->id,
             $this->name,
             $newMembers,
             $this->messages,
-            $this->sequenceNumber,
-            $this->version + 1,
+            $this->sequenceNumber + 1,
+            $this->version,
         );
-
+        $event = GroupChatEventFactory::ofMemberAdded(
+            $this->id,
+            $memberId,
+            $userAccountId,
+            $role,
+            $newState->getSequenceNumber(),
+            $executorId
+        );
         return [$newState, $event];
     }
 

--- a/src/Command/Domain/GroupChatEventFactory.php
+++ b/src/Command/Domain/GroupChatEventFactory.php
@@ -6,9 +6,13 @@ namespace Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain;
 
 use Ulid\Ulid;
 use DateTimeImmutable;
+use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Events\GroupChatCreated;
+use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Events\GroupChatMemberAdded;
+use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models\MemberId;
+use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models\MemberRole;
+use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models\UserAccountId;
 use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models\GroupChatId;
 use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models\GroupChatName;
-use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Events\GroupChatCreated;
 
 final class GroupChatEventFactory {
     public static function ofCreated(GroupChatId $id, GroupChatName $name): GroupChatCreated {
@@ -23,4 +27,28 @@ final class GroupChatEventFactory {
             $occurredAt
         );
     }
+
+    public static function ofMemberAdded(
+        GroupChatId     $id,
+        MemberId $memberId,
+        UserAccountId $userAccountId,
+        MemberRole $role,
+        UserAccountId $executorId
+    ): GroupChatMemberAdded {
+        $eventId = "group-chat-event-" . Ulid::generate();
+        $sequenceNumber = 1;
+        $occurredAt = new DateTimeImmutable('now');
+        return new GroupChatMemberAdded(
+            $eventId,
+            $id,
+            $memberId,
+            $userAccountId,
+            $role,
+            $executorId,
+            $sequenceNumber,
+            $occurredAt
+        );
+    }
+
+
 }

--- a/src/Command/Domain/GroupChatEventFactory.php
+++ b/src/Command/Domain/GroupChatEventFactory.php
@@ -33,10 +33,10 @@ final class GroupChatEventFactory {
         MemberId $memberId,
         UserAccountId $userAccountId,
         MemberRole $role,
+        int $sequenceNumber,
         UserAccountId $executorId
     ): GroupChatMemberAdded {
         $eventId = "group-chat-event-" . Ulid::generate();
-        $sequenceNumber = 1;
         $occurredAt = new DateTimeImmutable('now');
         return new GroupChatMemberAdded(
             $eventId,

--- a/src/Command/Domain/GroupChatWithEventPair.php
+++ b/src/Command/Domain/GroupChatWithEventPair.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain;
+
+use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Events\GroupChatEvent;
+
+readonly class GroupChatWithEventPair {
+    private GroupChat $groupChat;
+    private GroupChatEvent $event;
+
+    public function __construct(GroupChat $groupChat, GroupChatEvent $groupChatEvent) {
+        $this->groupChat = $groupChat;
+        $this->event = $groupChatEvent;
+    }
+
+    public function getGroupChat(): GroupChat {
+        return $this->groupChat;
+    }
+
+    public function getEvent(): GroupChatEvent {
+        return $this->event;
+    }
+}

--- a/src/Command/Domain/Models/GroupChatId.php
+++ b/src/Command/Domain/Models/GroupChatId.php
@@ -8,7 +8,7 @@ use J5ik2o\EventStoreAdapterPhp\AggregateId;
 use Ulid\Ulid;
 
 class GroupChatId implements AggregateId {
-    public const TYPE_NAME = "GroupChatId";
+    public const string TYPE_NAME = "GroupChatId";
     private readonly string $value;
 
     public function __construct() {

--- a/src/Command/Domain/Models/GroupChatName.php
+++ b/src/Command/Domain/Models/GroupChatName.php
@@ -2,8 +2,8 @@
 
 namespace Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models;
 
-class GroupChatName {
-    private readonly string $value;
+readonly class GroupChatName {
+    private string $value;
 
     public function __construct(string $value) {
         $this->value = $value;

--- a/src/Command/Domain/Models/Member.php
+++ b/src/Command/Domain/Models/Member.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models;
 
-class Member {
-    private readonly MemberId $id;
-    private readonly UserAccountId $userAccountId;
-    private readonly MemberRole $role;
+readonly class Member {
+    private MemberId $id;
+    private UserAccountId $userAccountId;
+    private MemberRole $role;
 
     public function __construct(
         MemberId $id,

--- a/src/Command/Domain/Models/MemberId.php
+++ b/src/Command/Domain/Models/MemberId.php
@@ -6,8 +6,8 @@ namespace Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models;
 
 use Ulid\Ulid;
 
-class MemberId {
-    private readonly string $value;
+readonly class MemberId {
+    private string $value;
 
     public function __construct() {
         $value = Ulid::generate();

--- a/src/Command/Domain/Models/Members.php
+++ b/src/Command/Domain/Models/Members.php
@@ -30,6 +30,10 @@ readonly class Members {
         return $this->values;
     }
 
+    /**
+     * @param UserAccountId $userAccountId
+     * @return Members
+     */
     public function addMember(UserAccountId $userAccountId): Members {
         $memberId = new MemberId();
         $member = new Member(
@@ -40,5 +44,18 @@ readonly class Members {
         $values = $this->values;
         $values[] = $member;
         return new Members($values);
+    }
+
+    /**
+     * @param UserAccountId $userAccountId
+     * @return Member|null
+     */
+    public function findByUserAccountId(UserAccountId $userAccountId): Member|null {
+        foreach ($this->values as $member) {
+            if ($member->getUserAccountId()->equals($userAccountId)) {
+                return $member;
+            }
+        }
+        return null;
     }
 }

--- a/src/Command/Domain/Models/Members.php
+++ b/src/Command/Domain/Models/Members.php
@@ -2,9 +2,9 @@
 
 namespace Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models;
 
-class Members {
+readonly class Members {
     /** @var array<Member> */
-    private readonly array $values;
+    private array $values;
 
     /**
      * @param array<Member> $values
@@ -20,8 +20,7 @@ class Members {
             $userAccountId,
             MemberRole::ADMIN_ROLE
         );
-        $members = new Members([$member]);
-        return $members;
+        return new Members([$member]);
     }
 
     /**
@@ -29,5 +28,17 @@ class Members {
      */
     public function getValues(): array {
         return $this->values;
+    }
+
+    public function addMember(UserAccountId $userAccountId): Members {
+        $memberId = new MemberId();
+        $member = new Member(
+            $memberId,
+            $userAccountId,
+            MemberRole::MEMBER_ROLE
+        );
+        $values = $this->values;
+        $values[] = $member;
+        return new Members($values);
     }
 }

--- a/src/Command/Domain/Models/Message.php
+++ b/src/Command/Domain/Models/Message.php
@@ -2,10 +2,10 @@
 
 namespace Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models;
 
-class Message {
-    private readonly MessageId $id;
-    private readonly string $text;
-    private readonly UserAccountId $senderId;
+readonly class Message {
+    private MessageId $id;
+    private string $text;
+    private UserAccountId $senderId;
 
     public function __construct(
         MessageId $id,

--- a/src/Command/Domain/Models/MessageId.php
+++ b/src/Command/Domain/Models/MessageId.php
@@ -4,8 +4,8 @@ namespace Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models;
 
 use Ulid\Ulid;
 
-class MessageId {
-    private readonly string $value;
+readonly class MessageId {
+    private string $value;
 
     public function __construct() {
         $value = (string) Ulid::generate();

--- a/src/Command/Domain/Models/Messages.php
+++ b/src/Command/Domain/Models/Messages.php
@@ -2,9 +2,9 @@
 
 namespace Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models;
 
-class Messages {
+readonly class Messages {
     /** @var array<Message> */
-    private readonly array $values;
+    private array $values;
 
     /**
      * @param array<Message> $values

--- a/src/Command/Domain/Models/UserAccountId.php
+++ b/src/Command/Domain/Models/UserAccountId.php
@@ -4,8 +4,8 @@ namespace Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models;
 
 use Ulid\Ulid;
 
-class UserAccountId {
-    private readonly string $value;
+readonly class UserAccountId {
+    private string $value;
 
     public function __construct() {
         $value = (string) Ulid::generate();

--- a/tests/Command/Domain/GroupChatTest.php
+++ b/tests/Command/Domain/GroupChatTest.php
@@ -16,15 +16,17 @@ class GroupChatTest extends TestCase {
         // Given
         $adminId = new UserAccountId();
         $name = new GroupChatName("test");
-        [$groupChat, $createdEvent] = GroupChat::create(
+        $groupChatWithEvent = GroupChat::create(
             $name,
             $adminId,
         );
+        $groupChat = $groupChatWithEvent->getGroupChat();
+
         $memberId = new MemberId();
         $userAccountId = new UserAccountId();
 
         // When
-        [$newGroupChat, $addedEvent] = $groupChat->addMember(
+        $groupChatWithEvent = $groupChat->addMember(
             $memberId,
             $userAccountId,
             MemberRole::MEMBER_ROLE,
@@ -32,6 +34,8 @@ class GroupChatTest extends TestCase {
         );
 
         // Then
+        $newGroupChat = $groupChatWithEvent->getGroupChat();
+        $addedEvent = $groupChatWithEvent->getEvent();
         $this->assertEquals($groupChat->getId(), $newGroupChat->getId());
         $this->assertNotEquals(
             null,

--- a/tests/Command/Domain/GroupChatTest.php
+++ b/tests/Command/Domain/GroupChatTest.php
@@ -32,7 +32,8 @@ class GroupChatTest extends TestCase {
         );
 
         // Then
-        $this->assertEquals($groupChat->getMembers()->getValues()[0]->getUserAccountId(), $adminId);
+        $this->assertEquals($groupChat->getId(), $newGroupChat->getId());
+        $this->assertTrue($groupChat->getMembers()->findByUserAccountId($userAccountId)->isPresent());
         $this->assertEquals($groupChat->getVersion() + 1, $newGroupChat->getVersion());
     }
 }

--- a/tests/Command/Domain/GroupChatTest.php
+++ b/tests/Command/Domain/GroupChatTest.php
@@ -33,7 +33,16 @@ class GroupChatTest extends TestCase {
 
         // Then
         $this->assertEquals($groupChat->getId(), $newGroupChat->getId());
-        $this->assertTrue($groupChat->getMembers()->findByUserAccountId($userAccountId)->isPresent());
-        $this->assertEquals($groupChat->getVersion() + 1, $newGroupChat->getVersion());
+        $this->assertNotEquals(
+            null,
+            $newGroupChat->getMembers()->findByUserAccountId($userAccountId)
+        );
+        $this->assertEquals(
+            $userAccountId,
+            $newGroupChat->getMembers()->findByUserAccountId($userAccountId)?->getUserAccountId()
+        );
+        $this->assertEquals($groupChat->getId(), $addedEvent->getAggregateId());
+        $this->assertEquals($groupChat->getSequenceNumber() + 1, $addedEvent->getSequenceNumber());
+        $this->assertEquals($groupChat->getSequenceNumber() + 1, $newGroupChat->getSequenceNumber());
     }
 }

--- a/tests/Command/Domain/GroupChatTest.php
+++ b/tests/Command/Domain/GroupChatTest.php
@@ -6,6 +6,8 @@ namespace Akinoriakatsuka\CqrsEsExamplePhp\Tests\Command\Domain;
 
 use PHPUnit\Framework\TestCase;
 use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\GroupChat;
+use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models\MemberId;
+use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models\MemberRole;
 use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models\GroupChatName;
 use Akinoriakatsuka\CqrsEsExamplePhp\Command\Domain\Models\UserAccountId;
 
@@ -18,10 +20,19 @@ class GroupChatTest extends TestCase {
             $name,
             $adminId,
         );
+        $memberId = new MemberId();
+        $userAccountId = new UserAccountId();
 
         // When
+        [$newGroupChat, $addedEvent] = $groupChat->addMember(
+            $memberId,
+            $userAccountId,
+            MemberRole::MEMBER_ROLE,
+            $adminId
+        );
 
         // Then
         $this->assertEquals($groupChat->getMembers()->getValues()[0]->getUserAccountId(), $adminId);
+        $this->assertEquals($groupChat->getVersion() + 1, $newGroupChat->getVersion());
     }
 }


### PR DESCRIPTION
## 変更の目的
GroupChatでAdminがMemberを追加できるようにする。

## 変更点
- `testGroupChatAddMember()`のAssertionを追加
- `addMember()`の実装
- (refactor) 戻り値に`GroupChatWithEventPair`を返すように変更
    - `GroupChatWithEventPair`クラスを新規作成
    - `GroupChatTest`クラスのテストメソッドを`GroupChatWithEventPair`に対応するよう修正
    - `GroupChat`の`create`メソッドと`addMember`メソッドの戻り値を`GroupChatWithEventPair`に変更
- (refactor) `readonly`クラスに変更
    - `GroupChatCreated`
    - `GroupChatName`
    - `Members`
    - `Member`
    - `Message`
    - `Messages`
    - `UserAccountId`